### PR TITLE
替换纯真 IP 库下载链接

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,12 @@ name: Release Build
 on:
   schedule:
     - cron: 3 20 * * 0
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - "**/README.md"
+      - "**/README_en.md"
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
     - name: Download chunzhen cn list
       run: |
           cd mmdb_china_ip_list
-          curl -L -o CN.txt "https://raw.githubusercontent.com/metowolf/iplist/master/data/country/CN.txt"
+          curl -LR -o CN.txt "https://raw.githubusercontent.com/metowolf/iplist/master/data/special/china.txt"
 
     - name: Build mmdb
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
       continue-on-error: true
       run: |
           cd writer
-          curl -LO http://xrl.us/cpanm
+          curl -LRO http://xrl.us/cpanm
           sudo -E perl cpanm –installdeps .
           
     - name: Build MaxMind-DB-Writer-perl
@@ -55,7 +55,7 @@ jobs:
     - name: Download GeoLite2-Country-CSV
       run: |
           cd mmdb_china_ip_list
-          curl -L -o GeoLite2-Country-CSV.zip "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-Country-CSV&license_key=JvbzLLx7qBZT&suffix=zip"
+          curl -LR -o GeoLite2-Country-CSV.zip "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-Country-CSV&license_key=JvbzLLx7qBZT&suffix=zip"
           unzip GeoLite2-Country-CSV.zip
           rm -f GeoLite2-Country-CSV.zip
           mv GeoLite2* mindmax
@@ -63,7 +63,7 @@ jobs:
     - name: Download china_ip_list
       run: |
           cd mmdb_china_ip_list
-          curl -L -o china_ip_list.txt "https://raw.githubusercontent.com/17mon/china_ip_list/master/china_ip_list.txt"
+          curl -LR -o china_ip_list.txt "https://raw.githubusercontent.com/17mon/china_ip_list/master/china_ip_list.txt"
 
     - name: Download chunzhen cn list
       run: |

--- a/README.md
+++ b/README.md
@@ -62,16 +62,16 @@ git clone https://github.com/alecthw/mmdb_china_ip_list.git
 cd mmdb_china_ip_list
 
 # 下载GeoLite2-Country-CSV
-curl -L -o GeoLite2-Country-CSV.zip "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-Country-CSV&license_key=JvbzLLx7qBZT&suffix=zip"
+curl -LR -o GeoLite2-Country-CSV.zip "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-Country-CSV&license_key=JvbzLLx7qBZT&suffix=zip"
 unzip GeoLite2-Country-CSV.zip
 rm -f GeoLite2-Country-CSV.zip
 mv GeoLite2* mindmax
 
 # 下载china_ip_list
-curl -L -o china_ip_list.txt "https://raw.githubusercontent.com/17mon/china_ip_list/master/china_ip_list.txt"
+curl -LR -o china_ip_list.txt "https://raw.githubusercontent.com/17mon/china_ip_list/master/china_ip_list.txt"
 
 # 下载纯真数据库的CN
-curl -L -o CN.txt "https://raw.githubusercontent.com/metowolf/iplist/master/data/country/CN.txt"
+curl -LR -o CN.txt "https://raw.githubusercontent.com/metowolf/iplist/master/data/special/china.txt"
 
 # 生成mmdb
 perl china_ip_list.pl

--- a/README_en.md
+++ b/README_en.md
@@ -65,16 +65,16 @@ git clone https://github.com/alecthw/mmdb_china_ip_list.git
 cd mmdb_china_ip_list
 
 # Download GeoLite2-Country-CSV
-curl -L -o GeoLite2-Country-CSV.zip "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-Country-CSV&license_key=JvbzLLx7qBZT&suffix=zip"
+curl -LR -o GeoLite2-Country-CSV.zip "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-Country-CSV&license_key=JvbzLLx7qBZT&suffix=zip"
 unzip GeoLite2-Country-CSV.zip
 rm -f GeoLite2-Country-CSV.zip
 mv GeoLite2* mindmax
 
 # Download china_ip_list
-curl -L -o china_ip_list.txt "https://raw.githubusercontent.com/17mon/china_ip_list/master/china_ip_list.txt"
+curl -LR -o china_ip_list.txt "https://raw.githubusercontent.com/17mon/china_ip_list/master/china_ip_list.txt"
 
 # Download Chunzhen CN
-curl -L -o CN.txt "https://raw.githubusercontent.com/metowolf/iplist/master/data/country/CN.txt"
+curl -LR -o CN.txt "https://raw.githubusercontent.com/metowolf/iplist/master/data/special/china.txt"
 
 # Generate mmdb
 perl china_ip_list.pl


### PR DESCRIPTION
使用经过合并后的 IP 段数据，Refer: https://github.com/metowolf/iplist#%E5%A4%A7%E9%99%86-ip-%E6%AE%B5